### PR TITLE
Android 14 support: Add extra permission and and device fallback

### DIFF
--- a/android/src/main/kotlin/com/sersoluciones/flutter_pos_printer_platform/usb/USBPrinterService.kt
+++ b/android/src/main/kotlin/com/sersoluciones/flutter_pos_printer_platform/usb/USBPrinterService.kt
@@ -83,7 +83,11 @@ class USBPrinterService private constructor(private var mHandler: Handler?) {
         }
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)
-        mContext!!.registerReceiver(mUsbDeviceReceiver, filter)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            mContext!!.registerReceiver(mUsbDeviceReceiver, filter, 4) // Context.RECEIVER_EXPORTED
+        } else {
+            mContext!!.registerReceiver(mUsbDeviceReceiver, filter)
+        }
         Log.v(LOG_TAG, "ESC/POS Printer initialized")
     }
 

--- a/android/src/main/kotlin/com/sersoluciones/flutter_pos_printer_platform/usb/USBPrinterService.kt
+++ b/android/src/main/kotlin/com/sersoluciones/flutter_pos_printer_platform/usb/USBPrinterService.kt
@@ -44,7 +44,7 @@ class USBPrinterService private constructor(private var mHandler: Handler?) {
                         state = STATE_USB_CONNECTED
                         mHandler?.obtainMessage(STATE_USB_CONNECTED)?.sendToTarget()
                     } else {
-                        Toast.makeText(context, mContext?.getString(R.string.user_refuse_perm) + ": ${usbDevice!!.deviceName}", Toast.LENGTH_LONG).show()
+                        Toast.makeText(context, mContext?.getString(R.string.user_refuse_perm) + ": ${usbDevice?.deviceName ?: "Unknown Device"}", Toast.LENGTH_LONG).show()
                         state = STATE_USB_NONE
                         mHandler?.obtainMessage(STATE_USB_NONE)?.sendToTarget()
                     }
@@ -70,10 +70,16 @@ class USBPrinterService private constructor(private var mHandler: Handler?) {
     fun init(reactContext: Context?) {
         mContext = reactContext
         mUSBManager = mContext!!.getSystemService(Context.USB_SERVICE) as UsbManager
+
+        val GetEXTRA_PERMISSION_GRANTEDIntent = Intent(ACTION_USB_PERMISSION).apply {
+            putExtra(UsbManager.EXTRA_PERMISSION_GRANTED, true)
+            setPackage(mContext?.packageName)
+        }
+
         mPermissionIndent = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            PendingIntent.getBroadcast(mContext, 0, Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_MUTABLE)
+            PendingIntent.getBroadcast(mContext, 0, GetEXTRA_PERMISSION_GRANTEDIntent, PendingIntent.FLAG_MUTABLE)
         } else {
-            PendingIntent.getBroadcast(mContext, 0, Intent(ACTION_USB_PERMISSION), 0)
+            PendingIntent.getBroadcast(mContext, 0, GetEXTRA_PERMISSION_GRANTEDIntent, 0)
         }
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)


### PR DESCRIPTION
- Add fallback for unknown device and add explicit intent
- Pass integer 4 (Context.RECEIVER_EXPORTED) to `mContext!!.registerReceiver` for `BroadcastReceiver` to be working on Android 14+ 

Credits to: https://github.com/diantahoc/flutter_pos_printer_platform/pull/6